### PR TITLE
fix composer.json a bit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,24 +25,13 @@
             }
         },
         {
-            "type": "package",
-            "package": {
-                "name"    : "fate/silex-extentions",
-                "version" : "dev-master",
-                "source"  : {
-                    "url"       : "https://github.com/fate/Silex-Extensions.git",
-                    "type"      : "git",
-                    "reference" : "origin/master"
-                },
-                "autoload": {
-                  "psr-0": {"SilexExtension": "src/"}
-                }
-            }
+            "type": "vcs",
+            "url": "https://github.com/fate/Silex-Extensions.git"
         }
     ],
     "require": {
         "php"                   : ">=5.3.2",
-        "silex/silex"           : "dev-master",
+        "silex/silex"           : "1.0.*",
         "twig/twig"             : "1.6.2",
         "monolog/monolog"       : ">=1.0.0",
         "symfony/form"          : "2.1.*",


### PR DESCRIPTION
Side note: You will still not be able to install the dependencies of fate/silex-extensions, as I told you. However, [there](https://github.com/mandango/mondator/pull/6) [are](https://github.com/mandango/mandango/pull/18) [pull requests](https://github.com/embedly/embedly-php/pull/7), which should hopefully be merged soon.
