### PR TITLE
Remove invalid classpaths and add Doctrine DBAL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "symfony/config"        : "2.1.*",
         "kriswallsmith/assetic" : "1.0.x-dev",
         "twitter/bootstrap"     : "1.4.0",
-        "fate/silex-extentions" : "dev-master"
+        "fate/silex-extentions" : "dev-master",
+        "doctrine/dbal"         : ">=2.1,<2.3"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,8 +1,12 @@
 {
-    "hash": "995b8e37e60b2a81d082d44e9c59d55e",
+    "hash": "691b7c4bf6814a873e27cae81408ebf1",
     "packages": [
         {
             "package": "doctrine/common",
+            "version": "2.2.1"
+        },
+        {
+            "package": "doctrine/dbal",
             "version": "2.2.1"
         },
         {
@@ -33,86 +37,72 @@
         {
             "package": "symfony/browser-kit",
             "version": "dev-master",
-            "source-reference": "15c0a5f96283399eabcd71a957522c3e39d646ef",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "f91ab705dc8f4fdfdc5baad0082a1263d77e147e"
         },
         {
             "package": "symfony/class-loader",
             "version": "dev-master",
-            "source-reference": "da83c40b126ce8622fc052332b2c54a135ed976c",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "cd1550a4a6c0794b6b109af2db43fde6e18ee363"
         },
         {
             "package": "symfony/config",
             "version": "dev-master",
-            "source-reference": "2360cb2273784f2b356c43dbcecfe1804730ee8d",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "94a0501a51791f845225186ad03ce586a7c73339"
         },
         {
             "package": "symfony/css-selector",
             "version": "dev-master",
-            "source-reference": "5fadf85067442c6aa0e76e407eca3a2b60e910c5",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "dd695aadd80d8e6e726a7a050535c04325cefa02"
         },
         {
             "package": "symfony/dom-crawler",
             "version": "dev-master",
-            "source-reference": "d35d208382d6e23a39a9e3c09357801b911eead6",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "9b4694da9a1239771468096c574d8309992a8454"
         },
         {
             "package": "symfony/event-dispatcher",
             "version": "dev-master",
-            "source-reference": "502614d7dcd2260d0adaef19a344cbd42aa29adf",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "07e1d0174f3a0ec36bbe04b3850270df7a86271d"
         },
         {
             "package": "symfony/finder",
             "version": "dev-master",
-            "source-reference": "be30ecc95281d729ee51b9e89644d442bcf60451",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "57ec7198a70e6c40e450ba66cc2f8ecab98746c8"
         },
         {
             "package": "symfony/form",
             "version": "dev-master",
-            "source-reference": "0a54c1e390d9f0f38efb618fc8bbeb7752ce327c",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "8cdce8f12c9e223550d83cc8a8d420fbd7eb8055"
         },
         {
             "package": "symfony/http-foundation",
             "version": "dev-master",
-            "source-reference": "6ba6f8bd8a27fe370cba501fd41429ceead119df",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "b9aceabb83f3d03fe451cdd867d987e863e7a25e"
         },
         {
             "package": "symfony/http-kernel",
             "version": "dev-master",
-            "source-reference": "05463806bf87b80b54bf2a6fcc8a1934a7260304",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "2048aa455abe5ca6089fab93fcb787742beb7e49"
         },
         {
             "package": "symfony/locale",
             "version": "dev-master",
-            "source-reference": "1ce08ac191f2b888c6a313ca22718b25834fc941",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "d84707d17c196e640019a8413f0764da46089a2d"
         },
         {
             "package": "symfony/process",
             "version": "dev-master",
-            "source-reference": "05d2c2b0372a616b1e9adaf90fd6c547c60b5d58",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "2e4da8c8076744bafed97451bb1574c96cda0e68"
         },
         {
             "package": "symfony/routing",
             "version": "dev-master",
-            "source-reference": "584d4b195eef8dac7fd3fb4515bb5c5c1e1cf803",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "0811d83da31aacfe32a580b5db4287cae8f3d5a9"
         },
         {
             "package": "symfony/translation",
             "version": "dev-master",
-            "source-reference": "d5a8647f65e5b6ff3483925fdc02fac010039f3e",
-            "alias": "2.1.9999999.9999999-dev"
+            "source-reference": "996c638a7bc7427290c140bec1fab62a0db1044c"
         },
         {
             "package": "symfony/twig-bridge",

--- a/src/app.php
+++ b/src/app.php
@@ -34,7 +34,6 @@ $app['translator.loader'] = new Symfony\Component\Translation\Loader\YamlFileLoa
 
 $app->register(new MonologServiceProvider(), array(
     'monolog.logfile'       => __DIR__.'/../log/app.log',
-    'monolog.class_path'    => __DIR__.'/../vendor/silex/vendor/monolog/src',
     'monolog.name'          => 'app',
     'monolog.level'         => 300 // = Logger::WARNING
 ));
@@ -52,9 +51,7 @@ $app->register(new DoctrineServiceProvider(), array(
         'host'      => $app['db.config.host'],
         'user'      => $app['db.config.user'],
         'password'  => $app['db.config.password'],
-    ),
-    'db.dbal.class_path'    => __DIR__ . '/../vendor/silex/vendor/doctrine-dbal/lib',
-    'db.common.class_path'  => __DIR__ . '/../vendor/silex/vendor/doctrine-common/lib',
+    )
 ));
 
 $app->register(new AsseticExtension(), array(


### PR DESCRIPTION
The Doctrine DBAL dependency was missing. Doctrine didn't work without this. There were also invalid classpaths in app.php for Monolog and Doctrine. I have removed them entirely as the Composer autoloader handles this. I assume these were a hangover from the switch to Composer.
